### PR TITLE
perf: Jit use 'pextrd' implicitly

### DIFF
--- a/CryptoBase/Digests/CRC32/Crc32X86.cs
+++ b/CryptoBase/Digests/CRC32/Crc32X86.cs
@@ -148,7 +148,7 @@ namespace CryptoBase.Digests.CRC32
 			x1 = Sse2.And(x1, Mask32);
 			x1 = Pclmulqdq.CarrylessMultiply(x1, RU, 0x00);
 			x1 = Sse2.Xor(x1, t);
-			return Sse41.IsSupported ? Sse41.Extract(x1.AsUInt32(), 0x01) : x1.AsUInt32().GetElement(1);
+			return x1.AsUInt32().GetElement(1); // pextrd eax, x1, 1
 		}
 
 		public void Dispose()

--- a/CryptoBase/Digests/CRC32C/Crc32CX86.cs
+++ b/CryptoBase/Digests/CRC32C/Crc32CX86.cs
@@ -158,7 +158,7 @@ namespace CryptoBase.Digests.CRC32C
 			x1 = Sse2.And(x1, Mask32);
 			x1 = Pclmulqdq.CarrylessMultiply(x1, RU, 0x00);
 			x1 = Sse2.Xor(x1, t);
-			return Sse41.IsSupported ? Sse41.Extract(x1.AsUInt32(), 0x01) : x1.AsUInt32().GetElement(1);
+			return x1.AsUInt32().GetElement(1); // pextrd eax, x1, 1
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
[Jit](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgCUBXAOwwEt8YaBJFqVp3KzC4A3AFgAUGUq1GLdpx4Y+AobhoANABxJxEycQDMlAEzkAIjHwRyAb0nlHlYw34ZyAQQAUASgdP7CSdg8gA3bCgwigBecgA1GDAMaCoTLRoAYVhsDBgvVxYaAFlsBDjsABsGGB8aD1wAVSVUXz0Qp2IAdii6xqVDE18aAHEYDABRCqsYFi8qHzanAF9/R1XncgL3ACFfdcD2x3DI0Jj4xOSoVPSsmBy8reLS8qqa3qaWFoX14NPyWIAyrgYCYaACABasABmGDorAA5uCMAAZCDwoSVa7bVgo7BMPKnNDkFDfIKHLo9eofDADIYAFQgALAlQirXWKzJa05Gy25Aye25B0Oxyi/3OSRSaUy2Vy+TcTzKlWqtSpzRQbO5wQpQJgKFo4wQymwSS8p3e/UGPiJpAQpHmi0cHKWQA=)
